### PR TITLE
IxD hotfix for esc key to close modal

### DIFF
--- a/public/javascript/photonview.js
+++ b/public/javascript/photonview.js
@@ -346,6 +346,13 @@ Photon.view = (function(pubsub){
       $modals.removeClass('is-active');
     });
 
+    $(document).on('keydown', function(evt){
+      if (evt.keyCode == 27){
+        $modals.removeClass('is-active');
+      }
+    });
+
+
     $loginBtn.on('click', function(){
       $loginBox.addClass('is-active');
     });


### PR DESCRIPTION
we can now close all modals (picture and login) on `esc` key
